### PR TITLE
Default template produced errors

### DIFF
--- a/lib/librarian/puppet/templates/Puppetfile
+++ b/lib/librarian/puppet/templates/Puppetfile
@@ -1,5 +1,5 @@
-# mod 'stdlib'
-#   :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git
+# mod 'stdlib',
+#   :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git'
 
 # mod 'apt',
 #   :git => 'https://github.com/puppetlabs/puppetlabs-apt.git',


### PR DESCRIPTION
... which turned out to be a quick-fix.

Thanks again for the awesome tool!

```
ozymandias:test$ librarian-puppet init
      create  Puppetfile
ozymandias:test$ vim Puppetfile 
ozymandias:test$ librarian-puppet update --verbose

[Librarian] Ruby Version: 1.8.7
[Librarian] Ruby Platform: i686-darwin11
[Librarian] Rubygems Version: 1.8.13
[Librarian] Librarian Version: 0.0.23
[Librarian] Librarian Adapter: puppet
[Librarian] Project: /tmp/test
[Librarian] Specfile: Puppetfile
[Librarian] Lockfile: Puppetfile.lock
[Librarian] Git: /usr/local/bin/git
[Librarian] Git Version: git version 1.7.9.2
[Librarian] Git Environment Variables:
[Librarian]   GIT_PS1_SHOWDIRTYSTATE=true
[Librarian]   GIT_PS1_SHOWUNTRACKEDFILES=true
[Librarian] Pre-Cached Sources:
/opt/local/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.0/vendor/librarian/lib/librarian/dsl/receiver.rb:44:in `instance_binding': compile error (SyntaxError)
/opt/local/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.0/vendor/librarian/lib/librarian/dsl/receiver.rb:44: syntax error, unexpected tASSOC, expecting $end
  :git => 'git://github.com/puppetlabs/puppetlabs-stdlib.git
         ^
    from /opt/local/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.0/vendor/librarian/lib/librarian/dsl/receiver.rb:43:in `instance_binding'
    from /opt/local/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.0/vendor/librarian/lib/librarian/dsl/receiver.rb:33:in `run'
    from /opt/local/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.0/vendor/librarian/lib/librarian/dsl.rb:84:in `run'
    from /opt/local/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.0/vendor/librarian/lib/librarian/dsl.rb:74:in `tap'
    from /opt/local/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.0/vendor/librarian/lib/librarian/dsl.rb:74:in `run'
    from /opt/local/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.0/vendor/librarian/lib/librarian/dsl.rb:20:in `run'
    from /opt/local/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.0/vendor/librarian/lib/librarian/environment.rb:115:in `dsl'
    from /opt/local/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.0/vendor/librarian/lib/librarian/specfile.rb:18:in `read'
    from /opt/local/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.0/vendor/librarian/lib/librarian/action/resolve.rb:12:in `run'
    from /opt/local/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.0/vendor/librarian/lib/librarian/cli.rb:139:in `resolve!'
    from /opt/local/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.0/vendor/librarian/lib/librarian/cli.rb:85:in `update'
    from /opt/local/lib/ruby/gems/1.8/gems/thor-0.15.2/lib/thor/task.rb:27:in `send'
    from /opt/local/lib/ruby/gems/1.8/gems/thor-0.15.2/lib/thor/task.rb:27:in `run'
    from /opt/local/lib/ruby/gems/1.8/gems/thor-0.15.2/lib/thor/invocation.rb:120:in `invoke_task'
    from /opt/local/lib/ruby/gems/1.8/gems/thor-0.15.2/lib/thor.rb:275:in `dispatch'
    from /opt/local/lib/ruby/gems/1.8/gems/thor-0.15.2/lib/thor/base.rb:408:in `start'
    from /opt/local/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.0/vendor/librarian/lib/librarian/cli.rb:33:in `bin!'
    from /opt/local/lib/ruby/gems/1.8/gems/librarian-puppet-0.9.0/bin/librarian-puppet:9
    from /opt/local/bin/librarian-puppet:19:in `load'
    from /opt/local/bin/librarian-puppet:19
```
