### PR TITLE
adjust install directive

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ stored as a directory under our `puppet-modules` git repos.
 
 Install librarian-puppet:
 
-    $ gem install --pre librarian-puppet
+    $ gem install librarian-puppet
 
 Prepare your puppet infrastructure repository:
 


### PR DESCRIPTION
The documentation said to install the pre version.
However this version is older than the current stable version.

~$ gem search --remote --pre librarian-puppet
librarian-puppet (0.0.1.pre2, 0.0.1.pre)

~$ gem search --remote librarian-puppet
librarian-puppet (0.9.0)
