### PR TITLE
tmp is added to gitignore but .tmp is used fixes #8

### DIFF
--- a/lib/librarian/puppet/cli.rb
+++ b/lib/librarian/puppet/cli.rb
@@ -27,7 +27,7 @@ module Librarian
           gitignore = []
         end
 
-        gitignore << "tmp/" unless gitignore.include? "tmp/"
+        gitignore << ".tmp/" unless gitignore.include? ".tmp/"
         gitignore << "modules/" unless gitignore.include? "modules/"
 
         File.open(".gitignore", 'w') do |f|


### PR DESCRIPTION
Added the . in front of tmp/ as suggested by @monolar
