### PR TITLE
Explicitly require rubygems

### DIFF
--- a/bin/librarian-puppet
+++ b/bin/librarian-puppet
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require 'rubygems'
+
 lib = File.expand_path('../../lib', __FILE__)
 vendor = File.expand_path('../../vendor/librarian/lib', __FILE__)
 $:.unshift(lib) unless $:.include?(lib)


### PR DESCRIPTION
Add an explicit require of rubygems.

This is to support the case where a user would install
librarian-puppet from source, but install its dependencies
as gems.
