### PR TITLE
Add lib/facter to list of manifest checked directories for local sources

### DIFF
--- a/lib/librarian/puppet/source/local.rb
+++ b/lib/librarian/puppet/source/local.rb
@@ -46,6 +46,7 @@ module Librarian
         def manifest?(name, path)
           return true if path.join('manifests').exist?
           return true if path.join('lib').join('puppet').exist?
+          return true if path.join('lib').join('facter').exist?
           false
         end
       end


### PR DESCRIPTION
Howdy,

I have a few modules that just provide facts - they have a lib/facter but no manifests or lib/puppet directory.

Librarian puppet was choking on them

This nice easy patch fixes that - I didn't update README as I figured you would if you released a new version.

Thanks
