### PR TITLE
Git dependencies

### DIFF
--- a/lib/librarian/puppet/source/git.rb
+++ b/lib/librarian/puppet/source/git.rb
@@ -100,8 +100,12 @@ module Librarian
 
         def fetch_dependencies(name, version, extra)
           repository.dependencies.map do |k, v|
-            Dependency.new(k, v, nil)
+            Dependency.new(k, v, forge_source)
           end
+        end
+
+        def forge_source
+          Forge.from_lock_options(environment, :remote=>"http://forge.puppetlabs.com")
         end
 
       end


### PR DESCRIPTION
Fixes git dependencies fetched from the Modulefile in the git repo (rodjek/librarian-puppet#23).
