### PR TITLE
Teach outdated and show about git SHAs

### DIFF
--- a/lib/librarian/puppet/cli.rb
+++ b/lib/librarian/puppet/cli.rb
@@ -4,6 +4,12 @@ require 'librarian/cli'
 require 'librarian/puppet'
 
 module Librarian
+  class Cli < Thor
+    autoload :ManifestPresenter, "librarian/puppet/cli/manifest_presenter"
+  end
+end
+
+module Librarian
   module Puppet
     class Cli < Librarian::Cli
 

--- a/lib/librarian/puppet/cli.rb
+++ b/lib/librarian/puppet/cli.rb
@@ -83,6 +83,31 @@ module Librarian
         install
       end
 
+      desc "outdated", "Lists outdated dependencies."
+      option "verbose", :type => :boolean, :default => false
+      option "line-numbers", :type => :boolean, :default => false
+      def outdated
+        ensure!
+        resolution = environment.lock
+        resolution.manifests.sort_by(&:name).each do |manifest|
+          source = manifest.source
+          source_manifest = source.manifests(manifest.name).first
+          if source.class == Librarian::Puppet::Source::Git
+            next if manifest.version == source_manifest.version && manifest.source.sha == source_manifest.source.sha
+          else
+            next if manifest.version == source_manifest.version
+          end
+
+          source_sha = source
+          if manifest.source.class == Librarian::Puppet::Source::Git
+            sha = " #{manifest.source.sha[0..6]}"
+            source_sha = " #{source_manifest.source.sha[0..6]}"
+          end
+          say "#{manifest.name} (#{manifest.version}#{sha} -> #{source_manifest.version}#{source_sha})"
+        end
+      end
+
+
       def version
         say "librarian-puppet v#{Librarian::Puppet::VERSION}"
       end

--- a/lib/librarian/puppet/cli/manifest_presenter.rb
+++ b/lib/librarian/puppet/cli/manifest_presenter.rb
@@ -1,0 +1,27 @@
+require 'librarian/cli/manifest_presenter'
+module Librarian
+  class Cli
+    class ManifestPresenter
+
+      def present_one(manifest, options = { })
+        full = options[:detailed]
+
+        if manifest.source.class == Librarian::Puppet::Source::Git
+          sha = " #{manifest.source.sha[0..6]}"
+        end
+        say "#{manifest.name} (#{manifest.version}#{sha})" do
+          if full
+            say "source: #{manifest.source}"
+            unless manifest.dependencies.empty?
+              say "dependencies:" do
+                manifest.dependencies.sort_by(&:name).each do |dependency|
+                  say "#{dependency.name} (#{dependency.requirement})"
+                end
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/librarian/puppet/source/git.rb
+++ b/lib/librarian/puppet/source/git.rb
@@ -25,6 +25,17 @@ module Librarian
           metadata.version
         end
 
+        def manifests(source, name)
+          if source.send(:repository_cached?)
+            source = source.dup
+            source.send(:sha=, current_commit_hash)
+            [Manifest.new(source, name, module_version)]
+          else
+            manifest = Manifest.new(source, name, module_version)
+            [manifest].compact
+          end
+        end
+
         def dependencies
           return {} unless modulefile?
 
@@ -106,6 +117,15 @@ module Librarian
 
         def forge_source
           Forge.from_lock_options(environment, :remote=>"http://forge.puppetlabs.com")
+        end
+
+        def manifests(name)
+          repository.manifests(self, name)
+        end
+
+        def to_s
+          short_sha = sha ? sha[0..6] : nil
+          path ? "#{uri}##{ref}-#{short_sha}(#{path})" : "#{uri}##{ref}-#{short_sha}"
         end
 
       end


### PR DESCRIPTION
Added the git sha to show for git sources so you know what SHA you are currently using

Made sure that outdated takes the SHA and not just the Modulefile version into account when checking if modules are outdated

Should close #23
