### PR TITLE
don't fail if tags have a leading v, for now we just ignore them

### DIFF
--- a/lib/librarian/puppet/source/githubtarball.rb
+++ b/lib/librarian/puppet/source/githubtarball.rb
@@ -22,7 +22,8 @@ module Librarian
               raise Error, "Unable to find module '#{source.uri}' on https://github.com"
             end
 
-            data.map { |r| r['name'] }.sort.reverse
+            all_versions = data.map { |r| r['name'] }.sort.reverse
+            all_versions.reject { |version| version =~ /^v/ }.compact
           end
 
           def manifests


### PR DESCRIPTION
previously it'd blow up; now it'll just silently ignore them

this also provides a good potential point to support them down the road.

I've tested this out with `puppetlabs/puppetlabs-stdlib` which has mixed versions
