### PR TITLE
Handles release candidates when checking for puppet version

### DIFF
--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -109,7 +109,7 @@ module Librarian
 
           def check_puppet_module_options
             min_version    = Gem::Version.create('2.7.13')
-            puppet_version = Gem::Version.create(`puppet --version`.strip)
+            puppet_version = Gem::Version.create(`puppet --version`.strip.gsub('-', '.'))
 
             if puppet_version < min_version
               raise Error, "To get modules from the forge, we use the puppet faces module command. Your current version does not support the options #{options.join(',')} . For this you need at least puppet version 2.7.13 and you have #{puppet_version}"


### PR DESCRIPTION
Solves @dickolsson [issue](https://github.com/rodjek/librarian-puppet/pull/37#issuecomment-9562394) when using a RC Puppet version
