### PR TITLE
Forge module version is ignored and support 1.x type versions

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,14 @@
 require 'bundler/setup'
 require 'cucumber/rake/task'
+require 'rspec/core/rake_task'
 require 'bundler/gem_tasks'
 require 'rake/testtask'
 require 'rake/clean'
-require 'bundler/gem_tasks'
 
 CLEAN.include('pkg/', 'tmp/')
 CLOBBER.include('Gemfile.lock')
 
+RSpec::Core::RakeTask.new
 Cucumber::Rake::Task.new(:features)
 
 Rake::TestTask.new do |test|
@@ -15,4 +16,4 @@ Rake::TestTask.new do |test|
   test.verbose = true
 end
 
-task :default => [:test, :features]
+task :default => [:test, :spec, :features]

--- a/features/update.feature
+++ b/features/update.feature
@@ -1,9 +1,8 @@
 Feature: cli/update
   Puppet librarian needs to update modules properly
 
-  @pending
   Scenario: Updating a module
-    Given PENDING a file named "Puppetfile" with:
+    Given a file named "Puppetfile" with:
     """
     forge "http://forge.puppetlabs.com"
 

--- a/lib/librarian/puppet/requirement.rb
+++ b/lib/librarian/puppet/requirement.rb
@@ -11,10 +11,14 @@ module Librarian
         if range_requirement?
           [@range_match[1], @range_match[2]]
         elsif pessimistic_requirement?
-          "~> #{@pessimistic_match[1]}"
+          "~> #{@pessimistic_match[1]}.0"
         else
           requirement
         end
+      end
+
+      def to_s
+        gem_requirement.to_s
       end
 
       private

--- a/spec/manifest_version_spec.rb
+++ b/spec/manifest_version_spec.rb
@@ -1,0 +1,94 @@
+require "librarian/manifest"
+
+describe Librarian::Manifest::Version do
+
+  describe "version comparison" do
+
+    context "when version has only two components" do
+      it "creates a new version with only 2 version components" do
+        v1 = described_class.new("1.0")
+      end
+    end
+
+    context "when neither version has pre-release items" do
+      it "compares 1.0.0 < 2.0.0" do
+        v1 = described_class.new("1.0.0")
+        v2 = described_class.new("2.0.0")
+        expect(v1 <=> v2).to eq(-1)
+      end
+      it "compares 2.0.0 < 2.1.0" do
+        v1 = described_class.new("2.0.0")
+        v2 = described_class.new("2.1.0")
+        expect(v1 <=> v2).to eq(-1)
+      end
+      it "compares 2.1.0 < 2.1.1" do
+        v1 = described_class.new("2.1.0")
+        v2 = described_class.new("2.1.1")
+        expect(v1 <=> v2).to eq(-1)
+      end
+    end
+
+    context "when versions have pre-release information" do
+      it "compares 1.0.0-alpha < 1.0.0-alpha1" do
+        v1 = described_class.new("1.0.0-alpha")
+        v2 = described_class.new("1.0.0-alpha.1")
+        expect(v1 <=> v2).to eq(-1)
+      end
+      it "compares 1.0.0-alpha.1 < 1.0.0-alpha.beta" do
+        v1 = described_class.new("1.0.0-alpha.1")
+        v2 = described_class.new("1.0.0-alpha.beta")
+        expect(v1 <=> v2).to eq(-1)
+      end
+      it "compares 1.0.0-alpha.beta < 1.0.0-beta" do
+        v1 = described_class.new("1.0.0-alpha.beta")
+        v2 = described_class.new("1.0.0-beta")
+        expect(v1 <=> v2).to eq(-1)
+      end
+      it "compares 1.0.0-beta < 1.0.0-beta.2" do
+        v1 = described_class.new("1.0.0-beta")
+        v2 = described_class.new("1.0.0-beta.2")
+        expect(v1 <=> v2).to eq(-1)
+      end
+      it "compares 1.0.0-beta.2 < 1.0.0-beta.11" do
+        v1 = described_class.new("1.0.0-beta.2")
+        v2 = described_class.new("1.0.0-beta.11")
+        expect(v1 <=> v2).to eq(-1)
+      end
+      it "compares 1.0.0-beta.11 < 1.0.0-rc.1" do
+        v1 = described_class.new("1.0.0-beta.11")
+        v2 = described_class.new("1.0.0-rc.1")
+        expect(v1 <=> v2).to eq(-1)
+      end
+      it "compares 1.0.0-rc.1 < 1.0.0" do
+        v1 = described_class.new("1.0.0-rc.1")
+        v2 = described_class.new("1.0.0")
+        expect(v1 <=> v2).to eq(-1)
+      end
+    end
+
+    context "when an invalid version number is provided" do
+      it "raises" do
+        expect { described_class.new("invalidversion") }.
+            to raise_error(ArgumentError)
+      end
+    end
+
+    context "when a version is converted to string" do
+      it "should be the full semver" do
+        version = "1.0.0-beta.11+200.1.2"
+        v1 = described_class.new(version)
+        expect(v1.to_s).to eq(version)
+      end
+      it "should be the full gem version" do
+        version = "1.0.0.a"
+        v1 = described_class.new(version)
+        expect(v1.to_s).to eq(version)
+      end
+      it "should be the two-component version" do
+        version = "1.0"
+        v1 = described_class.new(version)
+        expect(v1.to_s).to eq(version)
+      end
+    end
+  end
+end

--- a/spec/requirement_spec.rb
+++ b/spec/requirement_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Librarian::Puppet::Requirement do
+
+  it 'should handle .x versions' do
+    described_class.new('1.x').gem_requirement.should eq('~> 1.0')
+    described_class.new('1.0.x').gem_requirement.should eq('~> 1.0.0')
+  end
+
+  it 'should handle version ranges' do
+    described_class.new('>=1.1.0 <2.0.0').gem_requirement.should eq(['>=1.1.0', '<2.0.0'])
+  end
+
+  it 'should print to_s' do
+    described_class.new('1.x').to_s.should eq('~> 1.0')
+    described_class.new('>=1.1.0 <2.0.0').to_s.should eq("[\">=1.1.0\", \"<2.0.0\"]")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'rubygems'
+require 'rspec'
+
+require 'librarian/puppet'


### PR DESCRIPTION
Added the cucumber tests for both cases, tested on 3.0.1 and 2.7.14

Supersedes https://github.com/rodjek/librarian-puppet/issues/56 and https://github.com/rodjek/librarian-puppet/issues/45
