### PR TITLE
Remove Puppet Gem Dependency

### DIFF
--- a/lib/librarian/puppet.rb
+++ b/lib/librarian/puppet.rb
@@ -1,5 +1,4 @@
 require 'librarian'
-require 'puppet'
 require 'fileutils'
 
 require 'librarian/puppet/extension'

--- a/librarian-puppet.gemspec
+++ b/librarian-puppet.gemspec
@@ -24,7 +24,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "thor", "~> 0.15"
   s.add_dependency "json"
-  s.add_dependency "puppet"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "cucumber"


### PR DESCRIPTION
`librarian-puppet` has a hard dependency on the Puppet _gem_ in the
gemspec and requires it in `lib/librarian/puppet.rb`. In fact, there
is no hard dependency in the code itself that requires the Puppet source
to be available, and many installations do not use the gem (specifically
Windows).

`librarian-puppet` only requires Puppet because it shells out to it in
certain cases.

On Windows, Mac, and most Linux, there are binary packages
available, and I prefer these. I also like to use librarian-puppet. On
Windows, I can't do this because the gem doesn't work in cygwin, and I
currently have to run librarian-puppet in Cygwin on Windows.

In the future I recommend adding a check for the "puppet" binary on the
PATH if you need to shell out, but removing this dep doesn't break
anything otherwise.
