### PR TITLE
Ignore invalid versions in the forge, ie. 0.5.0-rc1

### DIFF
--- a/features/install.feature
+++ b/features/install.feature
@@ -14,6 +14,18 @@ Feature: cli/install
     And the file "modules/apt/Modulefile" should match /name *'puppetlabs-apt'/
     And the file "modules/stdlib/Modulefile" should match /name *'puppetlabs-stdlib'/
 
+  Scenario: Installing a module with invalid versions in the forge
+    Given a file named "Puppetfile" with:
+    """
+    forge "http://forge.puppetlabs.com"
+
+    mod 'puppetlabs/apache', '0.4.0'
+    """
+    When I run `librarian-puppet install`
+    Then the exit status should be 0
+    And the file "modules/apache/Modulefile" should match /name *'puppetlabs-apache'/
+    And the file "modules/apache/Modulefile" should match /version *'0\.4\.0'/
+
   Scenario: Changing the path
     Given a directory named "puppet"
     And a file named "Puppetfile" with:

--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -22,7 +22,9 @@ module Librarian
               raise Error, "Unable to find module '#{name}' on #{source}"
             end
 
-            data['releases'].map { |r| r['version'] }.sort.reverse
+            versions = data['releases'].map { |r| r['version'] }.sort.reverse
+            versions.select { |v| ! Gem::Version.correct? v }.each { |v| debug { "Ignoring invalid version '#{v}' for module #{name}" } }
+            versions.select { |v| Gem::Version.correct? v }
           end
 
           def dependencies(version)
@@ -104,7 +106,6 @@ module Librarian
               path.unlink
               raise Error, "Error executing puppet module install:\n#{command}\nError:\n#{output}"
             end
-
           end
 
           def check_puppet_module_options
@@ -146,6 +147,10 @@ module Librarian
 
               res.read_body(&block)
             end
+          end
+
+          def debug(*args, &block)
+            environment.logger.debug(*args, &block)
           end
 
         private


### PR DESCRIPTION
Instead of failing completely

For instance for the apache module 
http://forge.puppetlabs.com/puppetlabs/apache/0.5.0-rc1

Pushed as librarian-puppet-maestrodev 0.9.7.2 from 
https://github.com/maestrodev/librarian-puppet/tree/maestrodev
https://rubygems.org/gems/librarian-puppet-maestrodev
