### PR TITLE
Prevent error when using any module with a release candidate

### DIFF
--- a/features/install.feature
+++ b/features/install.feature
@@ -29,3 +29,15 @@ Feature: cli/install
     And the file "puppet/modules/apt/Modulefile" should match /name *'puppetlabs-apt'/
     And the file "puppet/modules/stdlib/Modulefile" should match /name *'puppetlabs-stdlib'/
 
+  Scenario: Installing a module with a release candidate
+    Given a file named "Puppetfile" with:
+    """
+    forge "http://forge.puppetlabs.com"
+
+    mod 'puppetlabs/apache', '0.5.0.rc1'
+    """
+    When I run `librarian-puppet install`
+    Then the exit status should be 0
+    And the file "Puppetfile.lock" should contain "puppetlabs/apache (0.5.0.rc1)"
+    And the file "modules/apache/Modulefile" should match /version *'0.5.0-rc1'/
+

--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -26,7 +26,8 @@ module Librarian
           end
 
           def dependencies(version)
-            data = api_call("api/v1/releases.json?module=#{name}&version=#{version}")
+            original_version = version.to_s.gsub('.rc', '-rc')
+            data = api_call("api/v1/releases.json?module=#{name}&version=#{original_version}")
             data[name].first['dependencies']
           end
 

--- a/vendor/librarian/lib/librarian/manifest.rb
+++ b/vendor/librarian/lib/librarian/manifest.rb
@@ -29,7 +29,8 @@ module Librarian
       def initialize_normalize_args(args)
         args.map do |arg|
           arg = [arg] if self.class === arg
-          arg
+          ret = arg.gsub('-', '.')
+          ret
         end
       end
 


### PR DESCRIPTION
Some modules on the forge have versions like 0.5.0-rc1. It turns out
that the - causes havoc in Librarian, resulting in an exception that
blocks the use of librarian-puppet. I saw this first with the
puppetlabs/apache module. Basically if you include it or anything that
depends on it librarian-puppet won't work.

This patch resolves this in a hacky, but apparently working, way. It
replaces - with a period internally, and then swaps it again to a - when
making a call to the forge.
