### PR TITLE
Ensure equality comparisons work for Source objs

### DIFF
--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -204,6 +204,12 @@ module Librarian
           self.uri == other.uri
         end
 
+        alias :eql? :==
+
+        def hash
+          self.to_s.hash
+        end
+
         def to_spec_args
           [uri, {}]
         end

--- a/lib/librarian/puppet/source/githubtarball.rb
+++ b/lib/librarian/puppet/source/githubtarball.rb
@@ -161,6 +161,12 @@ module Librarian
           self.uri == other.uri
         end
 
+        alias :eql? :==
+
+        def hash
+          self.to_s.hash
+        end
+
         def to_spec_args
           [uri, {}]
         end

--- a/vendor/librarian/lib/librarian/chef/source/site.rb
+++ b/vendor/librarian/lib/librarian/chef/source/site.rb
@@ -363,6 +363,12 @@ module Librarian
           self.uri    == other.uri
         end
 
+        alias :eql? :==
+
+        def hash
+          self.to_s.hash
+        end
+
         def to_spec_args
           [uri, {}]
         end

--- a/vendor/librarian/lib/librarian/mock/source/mock.rb
+++ b/vendor/librarian/lib/librarian/mock/source/mock.rb
@@ -47,6 +47,12 @@ module Librarian
           self.name   == other.name
         end
 
+        alias :eql? :==
+
+        def hash
+          self.to_s.hash
+        end
+
         def to_spec_args
           [name, {}]
         end

--- a/vendor/librarian/lib/librarian/source/git.rb
+++ b/vendor/librarian/lib/librarian/source/git.rb
@@ -67,6 +67,12 @@ module Librarian
         (self.sha.nil? || other.sha.nil? || self.sha == other.sha)
       end
 
+      alias :eql? :==
+
+      def hash
+        self.to_s.hash
+      end
+
       def to_spec_args
         options = {}
         options.merge!(:ref => ref) if ref != DEFAULTS[:ref]

--- a/vendor/librarian/lib/librarian/source/path.rb
+++ b/vendor/librarian/lib/librarian/source/path.rb
@@ -47,6 +47,12 @@ module Librarian
         self.path   == other.path
       end
 
+      alias :eql? :==
+
+      def hash
+        self.to_s.hash
+      end
+
       def to_spec_args
         [path.to_s, {}]
       end


### PR DESCRIPTION
Implement functions eql? and hash as they are required for proper evaluation of functions like uniq.

This addresses the issue found in https://github.com/rodjek/librarian-puppet/issues/31 and https://github.com/rodjek/librarian-puppet/issues/35
