### PR TITLE
Introduces fixes to make test pass and suggest Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: ruby
+before_install: gem install puppet

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source :rubygems
 gemspec
+
+gem "puppet", :group => :test

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Librarian-puppet
+[![Build Status](https://travis-ci.org/rodjek/librarian-puppet.png?branch=master)](https://travis-ci.org/rodjek/librarian-puppet)
 
 ## Introduction
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -5,5 +5,5 @@ Before do
   slow_boot ||= RUBY_PLATFORM == "java"
   slow_boot ||= defined?(::Rubinius)
 
-  @aruba_timeout_seconds = slow_boot ? 10 : 2
+  @aruba_timeout_seconds = slow_boot ? 20 : 10
 end


### PR DESCRIPTION
Hi there @rodjek,

I notice that a different fork of librarian-puppet is currently using [Travis CI (of their project)](https://travis-ci.org/maestrodev/librarian-puppet) to run the tests. But it was red.
I fixed the tests and now it is running ok.

The issue was that 'puppet' was made a soft dependency, but if you run prepending `bundle exec` to it, it wouldn't be found because it is not specified on the Gemfile.
Now it is showing up on the Gemfile as of the test group of dependencies.
I would like to see your opinion on this.

I would like to suggest together with this pull request to put librarian-puppet under [Travis CI](https://travis-ci.org)
This pull request contains a small change on the README including a picture of the latest build.
