### PR TITLE
Convert puppet version requirements to rubygems format

### DIFF
--- a/features/install.feature
+++ b/features/install.feature
@@ -29,3 +29,23 @@ Feature: cli/install
     And the file "puppet/modules/apt/Modulefile" should match /name *'puppetlabs-apt'/
     And the file "puppet/modules/stdlib/Modulefile" should match /name *'puppetlabs-stdlib'/
 
+  Scenario: Handle range version numbers
+    Given a file named "Puppetfile" with:
+    """
+    forge "http://forge.puppetlabs.com"
+
+    mod 'puppetlabs/postgresql'
+    """
+    When I run `librarian-puppet install`
+    Then the exit status should be 0
+    And the file "modules/postgresql/Modulefile" should match /name *'puppetlabs-postgresql'/
+
+    Given a file named "Puppetfile" with:
+    """
+    forge "http://forge.puppetlabs.com"
+
+    mod 'puppetlabs/postgresql', :git => 'git://github.com/puppetlabs/puppet-postgresql'
+    """
+    When I run `librarian-puppet install`
+    Then the exit status should be 0
+    And the file "modules/postgresql/Modulefile" should match /name *'puppetlabs-postgresql'/

--- a/lib/librarian/puppet/requirement.rb
+++ b/lib/librarian/puppet/requirement.rb
@@ -1,0 +1,31 @@
+module Librarian
+  module Puppet
+    class Requirement
+      attr_reader :requirement
+
+      def initialize(requirement)
+        @requirement = requirement
+      end
+
+      def gem_requirement
+        if range_requirement?
+          [@range_match[1], @range_match[2]]
+        elsif pessimistic_requirement?
+          "~> #{@pessimistic_match[1]}"
+        else
+          requirement
+        end
+      end
+
+      private
+
+      def range_requirement?
+        @range_match ||= requirement.match(/(>=? ?\d+(?:\.\d+){0,2}) (<=? ?\d+(?:\.\d+){0,2})/)
+      end
+
+      def pessimistic_requirement?
+        @pessimistic_match ||= requirement.match(/(\d+(?:\.\d+)?)\.x/)
+      end
+    end
+  end
+end

--- a/lib/librarian/puppet/source.rb
+++ b/lib/librarian/puppet/source.rb
@@ -1,3 +1,4 @@
+require 'librarian/puppet/requirement'
 require 'librarian/puppet/source/path'
 require 'librarian/puppet/source/git'
 require 'librarian/puppet/source/forge'

--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -265,6 +265,7 @@ module Librarian
 
         def fetch_dependencies(name, version, version_uri)
           repo(name).dependencies(version).map do |k, v|
+            v = Requirement.new(v).gem_requirement
             Dependency.new(k, v, nil)
           end
         end

--- a/lib/librarian/puppet/source/git.rb
+++ b/lib/librarian/puppet/source/git.rb
@@ -100,6 +100,7 @@ module Librarian
 
         def fetch_dependencies(name, version, extra)
           repository.dependencies.map do |k, v|
+            v = Requirement.new(v).gem_requirement
             Dependency.new(k, v, forge_source)
           end
         end


### PR DESCRIPTION
Checks puppet requirement to see if it is the equivalent of pessimistic (`1.2.x`) or a range (`>=3.0.0 <4.0.0`) and converts them to their respective rubygems requirement (`~> 1.2` and `['>= 3.0.0', '<4.0.0']` respectively).

Addresses issue reported in #82 and #85.  Any feedback would be appreciated.
