### PR TITLE
1.x versions should translate to ~>1.0 gem requirement. Add specs

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,12 @@
-begin
-  require 'cucumber/rake/task'
-  Cucumber::Rake::Task.new(:features)
-
-  task :default => :features
-rescue LoadError
-end
-
+require 'rake/clean'
+require 'cucumber/rake/task'
+require 'rspec/core/rake_task'
 require 'bundler/gem_tasks'
+
+CLEAN.include('pkg/', 'tmp/')
+CLOBBER.include('Gemfile.lock')
+
+RSpec::Core::RakeTask.new
+Cucumber::Rake::Task.new(:features)
+
+task :default => [:spec, :features]

--- a/lib/librarian/puppet/requirement.rb
+++ b/lib/librarian/puppet/requirement.rb
@@ -11,10 +11,14 @@ module Librarian
         if range_requirement?
           [@range_match[1], @range_match[2]]
         elsif pessimistic_requirement?
-          "~> #{@pessimistic_match[1]}"
+          "~> #{@pessimistic_match[1]}.0"
         else
           requirement
         end
+      end
+
+      def to_s
+        gem_requirement.to_s
       end
 
       private

--- a/librarian-puppet.gemspec
+++ b/librarian-puppet.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "json"
 
   s.add_development_dependency "rake"
+  s.add_development_dependency "rspec"
   s.add_development_dependency "cucumber"
   s.add_development_dependency "aruba"
   s.add_development_dependency "puppet"

--- a/spec/requirement_spec.rb
+++ b/spec/requirement_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe Librarian::Puppet::Requirement do
+
+  it 'should handle .x versions' do
+    described_class.new('1.x').gem_requirement.should eq('~> 1.0')
+    described_class.new('1.0.x').gem_requirement.should eq('~> 1.0.0')
+  end
+
+  it 'should handle version ranges' do
+    described_class.new('>=1.1.0 <2.0.0').gem_requirement.should eq(['>=1.1.0', '<2.0.0'])
+  end
+
+  it 'should print to_s' do
+    described_class.new('1.x').to_s.should eq('~> 1.0')
+    described_class.new('>=1.1.0 <2.0.0').to_s.should eq("[\">=1.1.0\", \"<2.0.0\"]")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,7 @@
+require 'rubygems'
+require 'rspec'
+
+vendor = File.expand_path('../../vendor/librarian/lib', __FILE__)
+$:.unshift(vendor) unless $:.include?(vendor)
+
+require 'librarian/puppet'


### PR DESCRIPTION
Issue #87 doesn't handle correctly the 1.x versions, sets them to ~>1 instead of ~>1.0
