### PR TITLE
Check if requirement is set before matching version.

### DIFF
--- a/lib/librarian/puppet/requirement.rb
+++ b/lib/librarian/puppet/requirement.rb
@@ -8,12 +8,16 @@ module Librarian
       end
 
       def gem_requirement
-        if range_requirement?
-          [@range_match[1], @range_match[2]]
-        elsif pessimistic_requirement?
-          "~> #{@pessimistic_match[1]}"
+        if requirement
+          if range_requirement?
+            [@range_match[1], @range_match[2]]
+          elsif pessimistic_requirement?
+            "~> #{@pessimistic_match[1]}"
+          else
+            requirement
+          end
         else
-          requirement
+          '>= 0'
         end
       end
 


### PR DESCRIPTION
If requirement is nil and you try to .match a regex it will error:

```
[Librarian]                                                                 Checking sensu/0.5.0 <https://github.com/sensu/sensu-puppet.git#master>
/Library/Ruby/Gems/1.8/gems/librarian-puppet-0.9.8/lib/librarian/puppet/requirement.rb:23:in `range_requirement?': undefined method `match' for nil:NilClass (NoMethodError)
    from /Library/Ruby/Gems/1.8/gems/librarian-puppet-0.9.8/lib/librarian/puppet/requirement.rb:11:in `gem_requirement'
```

sensu-puppet specifies a dependency without a version `dependency 'puppetlabs/apt'`
