### PR TITLE
Ensure correct forge URL is passed to PMT when installing modules

### DIFF
--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -95,7 +95,7 @@ module Librarian
             target = vendored?(name, version) ? vendored_path(name, version) : name
 
 
-            command = "puppet module install --target-dir '#{path}' --modulepath '#{path}' --ignore-dependencies '#{target}'"
+            command = "puppet module install --target-dir '#{path}' --module_repository '#{source}' --modulepath '#{path}' --ignore-dependencies '#{target}'"
             output = `#{command}`
 
             # Check for bad exit code


### PR DESCRIPTION
If pulling modules from a forge other than what's configured in Puppet, we should make sure librarian-puppet is calling `puppet module install --module_repository {source}` to ensure the module is installed from the correct forge.
