### PR TITLE
Read deps from Puppetfiles in git repos

### DIFF
--- a/features/install.feature
+++ b/features/install.feature
@@ -49,3 +49,13 @@ Feature: cli/install
     When I run `librarian-puppet install`
     Then the exit status should be 0
     And the file "modules/postgresql/Modulefile" should match /name *'puppetlabs-postgresql'/
+  Scenario: Install a module with dependencies specified in a Puppetfile
+    Given a file named "Puppetfile" with:
+    """
+    mod 'super', :git => 'git://github.com/mpalmer/puppet-super'
+    
+    """
+    When I run `librarian-puppet install`
+    Then the exit status should be 0
+    And the file "modules/super/Puppetfile" should match /mod *'sub'/
+    And the file "Puppetfile.lock" should match /remote: git:..github\.com.mpalmer.puppet-sub/

--- a/lib/librarian/puppet/source/git.rb
+++ b/lib/librarian/puppet/source/git.rb
@@ -26,16 +26,21 @@ module Librarian
         end
 
         def dependencies
-          return {} unless modulefile?
+          return {} unless modulefile? or puppetfile?
+          
+          if modulefile?
+            metadata = ::Puppet::ModuleTool::Metadata.new
 
-          metadata = ::Puppet::ModuleTool::Metadata.new
+            ::Puppet::ModuleTool::ModulefileReader.evaluate(metadata, modulefile)
 
-          ::Puppet::ModuleTool::ModulefileReader.evaluate(metadata, modulefile)
-
-          metadata.dependencies.inject({}) do |h, dependency|
-            name = dependency.instance_variable_get(:@full_module_name)
-            version = dependency.instance_variable_get(:@version_requirement)
-            h.update(name => version)
+            metadata.dependencies.map do |dependency|
+              name = dependency.instance_variable_get(:@full_module_name)
+              version = dependency.instance_variable_get(:@version_requirement)
+              v = Librarian::Puppet::Requirement.new(version).gem_requirement
+              Dependency.new(name, v, forge_source)
+            end
+          elsif puppetfile?
+            Librarian::Puppet::Environment.new(:project_path => path).specfile.read.dependencies
           end
         end
 
@@ -45,6 +50,14 @@ module Librarian
 
         def modulefile?
           File.exists?(modulefile)
+        end
+        
+        def puppetfile?
+          File.exists?(File.join(path, 'Puppetfile'))
+        end
+
+        def forge_source
+          Librarian::Puppet::Source::Forge.from_lock_options(environment, :remote=>"http://forge.puppetlabs.com")
         end
       end
     end
@@ -99,14 +112,7 @@ module Librarian
         end
 
         def fetch_dependencies(name, version, extra)
-          repository.dependencies.map do |k, v|
-            v = Requirement.new(v).gem_requirement
-            Dependency.new(k, v, forge_source)
-          end
-        end
-
-        def forge_source
-          Forge.from_lock_options(environment, :remote=>"http://forge.puppetlabs.com")
+          repository.dependencies
         end
 
       end


### PR DESCRIPTION
It is rather annoying to have to release a module just so you can have it depend on other modules.  We've got an internal tree of modules that we can easily reference between, and it would be nice to be able to use Puppetfiles inside those module trees to do the dereferencing.  Well, now you can.

I avoided trying to put git support directly into ModuleTool, because that way lies madness (and CLAs).  I'm also rather conflicted about the use of external git repos in the test suite, but I decided to stick with existing practice rather than try to do anything clever like putting my test repos inside.
