### PR TITLE
Test against multiple rubies with .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,3 @@ rvm:
   - 2.0.0
   - 1.9.3
   - 1.8.7
-
- whitelist
- branches:
-   only:
-       - master
-


### PR DESCRIPTION
I would like to ensure that librarian-puppet builds against 1.8.7 since that is still the ruby used by the ubuntu 12.04 puppet package.
