### PR TITLE
Make Librarian::Manifest::Version Semver 2.0.0 compatible

### DIFF
--- a/vendor/librarian/lib/librarian/manifest.rb
+++ b/vendor/librarian/lib/librarian/manifest.rb
@@ -3,60 +3,93 @@ require 'rubygems'
 module Librarian
   class Manifest
 
-    class Version
-      @@SEMANTIC_VERSION_PATTERN = /^([0-9]+\.[0-9]+(?:\.[0-9]+)?)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/
-      def self.parse(version_string)
-        parsed = @@SEMANTIC_VERSION_PATTERN.match(version_string.strip)
-        raise ArgumentError, "Invalid Semantic Version String '#{version_string}'" unless parsed
-        {
-            :full_version   => parsed[0],
-            :version        => parsed[1],
-            :prerelease     => parsed[2],
-            :build          => parsed[3],
-            :prerelease_ids => self.parse_metadata(parsed[2])
-        }
+    class PreReleaseVersion
+
+      # Compares pre-release component ids using Semver 2.0.0 spec
+      def self.compare_components(this_id,other_id)
+        case # Strings have higher precedence than numbers
+          when (this_id.is_a?(Integer) and other_id.is_a?(String))
+            -1
+          when (this_id.is_a?(String) and other_id.is_a?(Integer))
+            1
+          else
+            this_id <=> other_id
+        end
       end
 
-      def self.parse_metadata(metadata)
-        if metadata.nil?
+      # Parses pre-release components `a.b.c` into an array ``[a,b,c]`
+      # Converts numeric components into +Integer+
+      def self.parse(prerelease)
+        if prerelease.nil?
           []
         else
-          metadata.split('.').collect do |id|
+          prerelease.split('.').collect do |id|
             id = Integer(id) if /^[0-9]+$/ =~ id
             id
           end
         end
       end
 
-      # Compare Pre-release Ids
-      def self.compare_ids(id1,id2)
-        if id1.is_a?(Integer) or id2.is_a?(Integer)
-          # Numeric ids have lower precedence than alpha ids
-          if id1.is_a?(String)
-            return 1
-          elsif id2.is_a?(String)
-            return -1
-          end
-        end
-        id1 <=> id2
-      end
-
       include Comparable
 
-      attr_reader :prerelease_ids
-      attr_reader :prerelease
-      attr_reader :full_version
+      attr_reader :components
 
-      def initialize(version)
-        semver = Version.parse(version)
-        self.backing    = Gem::Version.new(semver[:version])
-        @full_version   = semver[:full_version]
-        @prerelease     = semver[:prerelease]
-        @prerelease_ids = semver[:prerelease_ids]
+      def initialize(prerelease)
+        @prerelease = prerelease
+        @components = PreReleaseVersion.parse(prerelease)
       end
 
-      def has_prerelease?
-        not @prerelease.nil?
+      def to_s
+        @prerelease
+      end
+
+      def <=>(other)
+        # null-fill zip array to prevent loss of components
+        z = Array.new([components.length,other.components.length])
+
+        # Compare each component against the other
+        comp = z.zip(components,other.components).collect do |ids|
+          case # All components being equal, the version with more of them takes precedence
+            when ids[1].nil? # Self has less elements, other wins
+              -1
+            when ids[2].nil? # Other has less elements, self wins
+              1
+            else
+              PreReleaseVersion.compare_components(ids[1],ids[2])
+          end
+        end
+        # Chose the first non-zero comparison or return 0
+        comp.delete_if {|c| c == 0}[0] || 0
+      end
+    end
+    class Version
+      @@SEMANTIC_VERSION_PATTERN = /^([0-9]+\.[0-9]+(?:\.[0-9]+)?)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/
+      def self.parse_semver(version_string)
+        parsed = @@SEMANTIC_VERSION_PATTERN.match(version_string.strip)
+        if parsed
+          {
+            :full_version => parsed[0],
+            :version => parsed[1],
+            :prerelease => (PreReleaseVersion.new(parsed[2]) if parsed[2]),
+            :build => parsed[3]
+          }
+        end
+      end
+      include Comparable
+
+      attr_reader :prerelease
+
+      def initialize(*args)
+        args = initialize_normalize_args(args)
+        semver = Version.parse_semver(*args)
+        if semver
+          self.backing  = Gem::Version.new(semver[:version])
+          @prerelease   = semver[:prerelease]
+          @full_version = semver[:full_version]
+        else
+          self.backing  = Gem::Version.new(*args)
+          @full_version = to_gem_version.to_s
+        end
       end
 
       def to_gem_version
@@ -64,39 +97,35 @@ module Librarian
       end
 
       def <=>(other)
-        version_compare = to_gem_version <=> other.to_gem_version
-        if version_compare == 0 and (has_prerelease? or other.has_prerelease?)
-          # Versions without a prerelease version win over those which have one
-          if not has_prerelease? and other.has_prerelease?  # My version wins
-            1
-          elsif not other.has_prerelease? and has_prerelease? # Their version wins
-            -1
-          else # Both have pre-release versions; comparison is mandatory
-            z = Array.new([prerelease_ids.length,other.prerelease_ids.length].max)
-            (z.zip(prerelease_ids,other.prerelease_ids).collect { |ids|
-              if ids[1].nil? # self has less elements, other wins
-                -1
-              elsif ids[2].nil? # other has less elements, self wins
-                1
-              else
-                Version.compare_ids(ids[1],ids[2]) # Normal comparison of ids
-              end
-            }).delete_if {|c| c == 0}[0] || 0
+        cmp = to_gem_version <=> other.to_gem_version
+
+        # Should compare pre-release versions?
+        if cmp == 0 and not (prerelease.nil? and other.prerelease.nil?)
+          case # Versions without prerelease take precedence
+            when (prerelease.nil? and not other.prerelease.nil?)
+              1
+            when (not prerelease.nil? and other.prerelease.nil?)
+              -1
+            else
+              prerelease <=> other.prerelease
           end
         else
-          version_compare
+          cmp
         end
       end
 
       def to_s
-        if has_prerelease?
-          "#{to_gem_version.to_s}-#{@prerelease}"
-        else
-          to_gem_version.to_s
-        end
+        @full_version
       end
 
       private
+
+      def initialize_normalize_args(args)
+        args.map do |arg|
+          arg = [arg] if self.class === arg
+          arg
+        end
+      end
 
       attr_accessor :backing
     end
@@ -130,6 +159,14 @@ module Librarian
       defined_version == fetched_version
     end
 
+    def latest
+      @latest ||= source.manifests(name).first
+    end
+
+    def outdated?
+      latest.version > version
+    end
+
     def dependencies
       defined_dependencies || fetched_dependencies
     end
@@ -154,7 +191,7 @@ module Librarian
       source.install!(self)
     end
 
-    private
+  private
 
     attr_accessor :defined_version, :defined_dependencies
 

--- a/vendor/librarian/spec/unit/manifest_version_spec.rb
+++ b/vendor/librarian/spec/unit/manifest_version_spec.rb
@@ -72,5 +72,23 @@ describe Librarian::Manifest::Version do
             to raise_error(ArgumentError)
       end
     end
+
+    context "when a version is converted to string" do
+      it "should be the full semver" do
+        version = "1.0.0-beta.11+200.1.2"
+        v1 = described_class.new(version)
+        expect(v1.to_s).to eq(version)
+      end
+      it "should be the full gem version" do
+        version = "1.0.0.a"
+        v1 = described_class.new(version)
+        expect(v1.to_s).to eq(version)
+      end
+      it "should be the two-component version" do
+        version = "1.0"
+        v1 = described_class.new(version)
+        expect(v1.to_s).to eq(version)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Problem Summary

Semver 2.0.0 _prerelease_ section cannot be parsed by Gem::Version and causes
an exception at runtime when parsing the manifest of modules that include it (See #83).

I asked PuppetlLabs what the version scheme is on the Forge. 
They said it was currently Semver 1.0.0 but they are moving to 2.0.0 soon.
It looks like puppetlabs/ntp and some others have these versions already and it is causing problems.

Implemented according to the Semver 2.0.0 spec (http://semver.org/spec/v2.0.0.html)
## Changes
- Added Semver 2.0.0 support to Librarian::Manifest::Version
- Relaxed Semver constraints to support 2-number versions (ie: 1.0)
- Added specs to test conditions mentioned in semver spec
