### PR TITLE
Bug when fetching modules from forge using 'puppet module install'

### DIFF
--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -94,7 +94,7 @@ module Librarian
 
             target = vendored?(name, version) ? vendored_path(name, version) : name
 
-            # if we fell back to using the name only, we need to pass the --version parameter to 'puppet module install'
+            # if we fallback to using the name only, we need to pass the --version parameter to 'puppet module install'
             version_param = (target == name) ? "--version '#{version}'" : ''
 
             command = "puppet module install --target-dir '#{path}' --module_repository '#{source}' --modulepath '#{path}' --ignore-dependencies #{version_param} '#{target}'"


### PR DESCRIPTION
I had an issue where I was systematically getting the latest version of modules even if I specified earlier versions in my Puppetfile. Looks like there was a problem with the way `puppet module install` was getting invoked when no vendored cached versions was found locally: no `--version` parameter was being used.

This change fixed that issue for me. Let me know if there is something I missed.
