### PR TITLE
Add syntax detection to Puppetfile template

### DIFF
--- a/lib/librarian/puppet/templates/Puppetfile
+++ b/lib/librarian/puppet/templates/Puppetfile
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+#^syntax detection
+
 forge "http://forge.puppetlabs.com"
 
 # mod 'puppetlabs/stdlib'


### PR DESCRIPTION
https://github.com/applicationsonline/librarian-chef/blob/master/lib/librarian/chef/templates/Cheffile#L1-L2

This allow for nice syntax highlighting even without a `.rb` file type on the `Puppetfile`
