### PR TITLE
Create vendor source directory before attempting to write to it

### DIFF
--- a/lib/librarian/puppet/source/git.rb
+++ b/lib/librarian/puppet/source/git.rb
@@ -87,6 +87,7 @@ module Librarian
         end
 
         def cache_in_vendor(tmp_path)
+          environment.vendor!
           Dir.chdir(tmp_path.to_s) do
             %x{git archive #{sha} | gzip > #{vendor_tgz}}
           end


### PR DESCRIPTION
This fixes a bug I was seeing that looked like:

`sh: /Users/michaelnussbaum/.../spec/fixtures/vendor/puppet/source/15aacc0b2aa5d1f7430974a9805725283953744d.tar.gz: No such file or directory`
