### PR TITLE
Maintain File Modified Dates

### DIFF
--- a/lib/librarian/puppet/source/local.rb
+++ b/lib/librarian/puppet/source/local.rb
@@ -41,7 +41,7 @@ module Librarian
 
         def install_perform_step_copy!(found_path, install_path)
           debug { "Copying #{relative_path_to(found_path)} to #{relative_path_to(install_path)}" }
-          FileUtils.cp_r(found_path, install_path)
+          FileUtils.cp_r(found_path, install_path, :preserve => true)
         end
 
         def manifest?(name, path)


### PR DESCRIPTION
Allow repositories to maintain modified dates on files when they are copied into the modules directory. By doing this, we can create build scripts which will only process new files. In other words, we won't have lint and puppet parser validate go through every single file from every single repo...we can limit them to what has changed since the last build.
