### PR TITLE
Allow users to enable debugging for all commands.

### DIFF
--- a/lib/librarian/puppet/cli.rb
+++ b/lib/librarian/puppet/cli.rb
@@ -7,6 +7,14 @@ module Librarian
   module Puppet
     class Cli < Librarian::Cli
 
+      class_option :debug, :type => :boolean
+
+      def initialize(*)
+        super
+
+        environment.ui.instance_variable_set(:@debug, true) if options[:debug]
+      end
+
       module Particularity
         def root_module
           Puppet


### PR DESCRIPTION
Hey mate,

Found the addition of this option to be super handy.

Sorry about the use of instace_variable_get. I will be submitting a patch to librarian so I can remove this in the near future. Happy to open an issue to track the change?

Cheers,

Pauly
