### PR TITLE
Git dependencies in both Puppetfile and Modulefile cause a Cannot bounce Puppetfile.lock! error

### DIFF
--- a/features/install.feature
+++ b/features/install.feature
@@ -184,6 +184,17 @@ Feature: cli/install
     And the file "modules/with_puppetfile/Modulefile" should match /name *'with-puppetfile'/
     And the file "modules/test/Modulefile" should match /name *'librarian-test'/
 
+  @slow
+  Scenario: Install a module with dependencies specified in a Puppetfile and Modulefile
+    Given a file named "Puppetfile" with:
+    """
+    mod 'with_puppetfile', :git => 'https://github.com/rodjek/librarian-puppet.git', :path => 'features/examples/with_puppetfile_and_modulefile'
+    """
+    When I run `librarian-puppet install`
+    Then the exit status should be 0
+    And the file "modules/with_puppetfile/Modulefile" should match /name *'with-puppetfile-and-modulefile'/
+    And the file "modules/test/Modulefile" should match /name *'maestrodev-test'/
+
   Scenario: Install a module with conflicts
     Given a file named "Puppetfile" with:
     """

--- a/lib/librarian/puppet/extension.rb
+++ b/lib/librarian/puppet/extension.rb
@@ -32,6 +32,13 @@ module Librarian
         end.flatten
       end
     end
+
+    alias :eql? :==
+
+    def hash
+      self.to_s.hash
+    end
+
   end
 
   # Fixes for librarian not yet released in their gem

--- a/lib/librarian/puppet/source/git.rb
+++ b/lib/librarian/puppet/source/git.rb
@@ -68,7 +68,7 @@ module Librarian
         end
 
         def fetch_dependencies(name, version, extra)
-          dependencies = []
+          dependencies = Set.new
 
           if modulefile?
             metadata = ::Puppet::ModuleTool::Metadata.new
@@ -76,16 +76,16 @@ module Librarian
             ::Puppet::ModuleTool::ModulefileReader.evaluate(metadata, modulefile)
 
             metadata.dependencies.each do |dependency|
-              name = dependency.instance_variable_get(:@full_module_name)
+              dependency_name = dependency.instance_variable_get(:@full_module_name)
               version = dependency.instance_variable_get(:@version_requirement)
               gem_requirement = Requirement.new(version).gem_requirement
-              dependencies.push Dependency.new(name, gem_requirement, forge_source)
+              dependencies << Dependency.new(dependency_name, gem_requirement, forge_source)
             end
           end
 
           if specfile?
             spec = environment.dsl(Pathname(specfile))
-            dependencies.concat spec.dependencies
+            dependencies.merge spec.dependencies
           end
 
           dependencies


### PR DESCRIPTION
Introduced in Issue #159 7447e2d
Because dependencies are added twice to the resolution
