### PR TITLE
`require': no such file to load -- open3_backport (LoadError)

### DIFF
--- a/lib/librarian/puppet.rb
+++ b/lib/librarian/puppet.rb
@@ -1,7 +1,18 @@
 require 'librarian'
 require 'fileutils'
 require 'open3'
-require 'open3_backport' if RUBY_VERSION < '1.9'
+
+# require open3_backport in ruby 1.8 and install if not present
+# https://github.com/rodjek/librarian-puppet/issues/167
+if RUBY_VERSION < '1.9'
+  begin
+    require 'open3_backport'
+  rescue LoadError
+    require 'rubygems/dependency_installer.rb'
+    Gem::DependencyInstaller.new.install 'open3_backport'
+    require 'open3_backport'
+  end
+end
 
 status = nil
 out = nil


### PR DESCRIPTION
Copied from https://github.com/maestrodev/librarian-puppet/issues/16 (was raised for librarian-puppet-maestrodev but looks like it would affect this as well)

Hello,

I have a failure in Travis on Ruby 1.8.7 - the open3_backport gem isn't being installed. This appears to be due to the gemspec conditionally adding this as a dependency, but it's evaluated at build time, not install time, so the dependency isn't added to Ruby < 1.9 installs.

Apparently this is the required approach: http://en.wikibooks.org/wiki/Ruby_Programming/RubyGems#How_to_install_different_versions_of_gems_depending_on_which_version_of_ruby_the_installee_is_using

References:
- Test failure https://travis-ci.org/jfryman/puppet-nginx/jobs/16828741
- Discussion on Stack Overflow: http://stackoverflow.com/questions/4596606/rubygems-how-do-i-add-platform-specific-dependency/10249133#10249133
