### PR TITLE
Librarian-puppet package seems to get into an infinite loop

### DIFF
--- a/features/package.feature
+++ b/features/package.feature
@@ -1,0 +1,17 @@
+Feature: cli/package
+  Puppet librarian needs to package modules
+
+  Scenario: Packaging a module and its dependencies
+    Given a file named "Puppetfile" with:
+    """
+    forge "http://forge.puppetlabs.com"
+
+    mod 'puppetlabs/apt'
+    """
+    When I run `librarian-puppet package --verbose`
+    Then the exit status should be 0
+    And the file "modules/apt/Modulefile" should match /name *'puppetlabs-apt'/
+    And the file "modules/stdlib/Modulefile" should match /name *'puppetlabs-stdlib'/
+    And the following files should exist:
+      | vendor/puppet/cache/puppetlabs-apt-1.4.0.tar.gz    |
+      | vendor/puppet/cache/puppetlabs-stdlib-4.1.0.tar.gz |

--- a/lib/librarian/puppet/cli.rb
+++ b/lib/librarian/puppet/cli.rb
@@ -67,6 +67,7 @@ module Librarian
         environment.config_db.local['mode'] = options['local'] ? 'local' : nil
 
         resolve!
+        debug { "Install: dependencies resolved"}
         install!
       end
 

--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -13,12 +13,17 @@ module Librarian
           def initialize(source, name)
             self.source = source
             self.name = name
+            # API returned data for this module including all versions and dependencies, indexed by module name
+            # from http://forge.puppetlabs.com/api/v1/releases.json?module=#{name}
             @api_data = nil
+            # API returned data for this module and a specific version, indexed by version
+            # from http://forge.puppetlabs.com/api/v1/releases.json?module=#{name}&version=#{version}
+            @api_version_data = {}
           end
 
           def versions
             return @versions if @versions
-            @versions = api_data[name].map { |r| r['version'] }.reverse
+            @versions = api_data(name).map { |r| r['version'] }.reverse
             if @versions.empty?
               info { "No versions found for module #{name}" }
             else
@@ -28,7 +33,7 @@ module Librarian
           end
 
           def dependencies(version)
-            api_data[name].detect{|x| x['version'] == version.to_s}['dependencies']
+            api_version_data(name, version)['dependencies']
           end
 
           def manifests
@@ -127,12 +132,13 @@ module Librarian
           end
 
           def vendor_cache(name, version)
-            info = api_data[name].detect {|h| h['version'] == version.to_s }
-            File.open(vendored_path(name, version).to_s, 'w') do |f|
-              open("#{source}#{info['file']}") do |input|
-                while (buffer = input.read)
-                  f.write(buffer)
-                end
+            info = api_version_data(name, version)
+            url = "#{source}#{info[name].first['file']}"
+            path = vendored_path(name, version).to_s
+            debug { "Downloading #{url} into #{path}"}
+            File.open(path, 'wb') do |f|
+              open(url, "rb") do |input|
+                f.write(input.read)
               end
             end
           end
@@ -145,23 +151,36 @@ module Librarian
           end
 
         private
-          def api_data
-            return @api_data if @api_data
+
+          # get and cache the API data for a specific module with all its versions and dependencies
+          def api_data(module_name)
+            return @api_data[module_name] if @api_data
             # call API and cache data
-            @api_data = api_call(name)
+            @api_data = api_call(module_name)
             if @api_data.nil?
               raise Error, "Unable to find module '#{name}' on #{source}"
             end
-            @api_data
+            @api_data[module_name]
           end
 
-          def api_call(module_name)
-            debug { "Querying Forge API for module #{name}" }
+          # get and cache the API data for a specific module and version
+          def api_version_data(module_name, version)
+            # if we already got all the versions, find in cached data
+            return @api_data[module_name].detect{|x| x['version'] == version.to_s} if @api_data
+            # otherwise call the api for this version if not cached already
+            @api_version_data[version] = api_call(name, version) if @api_version_data[version].nil?
+            @api_version_data[version]
+          end
+
+          def api_call(module_name, version=nil)
             base_url = source.uri
-            path     = "api/v1/releases.json?module=#{module_name}"
+            path = "api/v1/releases.json?module=#{module_name}"
+            path = "#{path}&version=#{version}" unless version.nil?
+            url = "#{base_url}/#{path}"
+            debug { "Querying Forge API for module #{name}#{" and version #{version}" unless version.nil?}: #{url}" }
             
             begin
-              data = open("#{base_url}/#{path}") {|f| f.read}
+              data = open(url) {|f| f.read}
               JSON.parse(data)
             rescue OpenURI::HTTPError => e
               case e.io.status[0].to_i


### PR DESCRIPTION
I've just started looking into librarian-puppet on CentOS 6, Ruby 1.8.7, and it appears that when running librarian-puppet package it gets into an infinite loop when fetching from puppetforge. I'm fairly new to ruby, but the bit of code it seems to be tripping up on is in lib/librarian/puppet/source/forge.rb, in the vendor_cache function. The while loop which loops over input.read never finishes, as it would seem that without a length argument it returns the whole file each time. This only happens when calling package, install works fine.
