### PR TITLE
Reset some more ruby/gem env-variables before running "puppet"

### DIFF
--- a/lib/librarian/puppet.rb
+++ b/lib/librarian/puppet.rb
@@ -12,7 +12,7 @@ begin
   if RUBY_VERSION < '1.9'
     # Ruby 1.8.x backport of popen3 doesn't allow the 'env' hash argument
     # Not sanitizing the environment for the moment.
-    Open3.popen3('puppet --version') {|stdin, stdout, stderr, wait_thr|
+    Open3.popen3('puppet --version') { |stdin, stdout, stderr, wait_thr|
       pid = wait_thr.pid # pid of the started process.
       out = stdout.read
       err = stderr.read
@@ -20,7 +20,7 @@ begin
     }
   else
     env_reset = {'GEM_PATH' => nil, 'BUNDLE_APP_CONFIG' => nil, 'BUNDLE_CONFIG' => nil, 'BUNDLE_GEMFILE' => nil}
-    Open3.popen3(env_reset, 'puppet --version') {|stdin, stdout, stderr, wait_thr|
+    Open3.popen3(env_reset, 'puppet --version') { |stdin, stdout, stderr, wait_thr|
       pid = wait_thr.pid # pid of the started process.
       out = stdout.read
       err = stderr.read


### PR DESCRIPTION
Similar to #182 we're experiencing `puppet` not to run correctly,
because some ruby/gem environment is inherited from vagrant's embedded ruby.

This is happening now that librarian-puppet doesn't depend/use the gem's puppet anymore. 

Example error:

```
/Applications/Vagrant/embedded/gems/gems/bundler-1.5.3/lib/bundler/spec_set.rb:92:in `block in materialize': Could not find builder-3.2.2 in any of the sources (Bundler::GemNotFound)
```
