### PR TITLE
Reset all bundler, ruby and gem env vars before calling puppet

### DIFF
--- a/lib/librarian/puppet.rb
+++ b/lib/librarian/puppet.rb
@@ -19,8 +19,8 @@ begin
       status = wait_thr.value # Process::Status object returned.
     }
   else
-		env_reset = {'BUNDLE_APP_CONFIG' => nil, 'BUNDLE_CONFIG' => nil, 'BUNDLE_GEMFILE' => nil, 'BUNDLE_BIN_PATH' => nil,
-								 'RUBYLIB' => nil, 'RUBYOPT' => nil, 'GEMRC' => nil, 'GEM_PATH' => nil}
+    env_reset = {'BUNDLE_APP_CONFIG' => nil, 'BUNDLE_CONFIG' => nil, 'BUNDLE_GEMFILE' => nil, 'BUNDLE_BIN_PATH' => nil,
+                 'RUBYLIB' => nil, 'RUBYOPT' => nil, 'GEMRC' => nil, 'GEM_PATH' => nil}
     Open3.popen3(env_reset, 'puppet --version') { |stdin, stdout, stderr, wait_thr|
       pid = wait_thr.pid # pid of the started process.
       out = stdout.read


### PR DESCRIPTION
Followup from https://github.com/rodjek/librarian-puppet/pull/185
Unfortunately it wasn't enough :/

I was again getting mixed stack traces between the system's and vagrant's rubygems.. 

```
/Applications/Vagrant/embedded/gems/gems/bundler-1.5.3/lib/bundler/spec_set.rb:92:in `block in materialize': Could not find diff-lcs-1.2.5 in any of the sources (Bundler::GemNotFound)
    from /Applications/Vagrant/embedded/gems/gems/bundler-1.5.3/lib/bundler/spec_set.rb:85:in `map!'
    from /Applications/Vagrant/embedded/gems/gems/bundler-1.5.3/lib/bundler/spec_set.rb:85:in `materialize'
    from /Applications/Vagrant/embedded/gems/gems/bundler-1.5.3/lib/bundler/definition.rb:133:in `specs'
    from /Applications/Vagrant/embedded/gems/gems/bundler-1.5.3/lib/bundler/definition.rb:178:in `specs_for'
    from /Applications/Vagrant/embedded/gems/gems/bundler-1.5.3/lib/bundler/definition.rb:167:in `requested_specs'
    from /Applications/Vagrant/embedded/gems/gems/bundler-1.5.3/lib/bundler/environment.rb:18:in `requested_specs'
    from /Applications/Vagrant/embedded/gems/gems/bundler-1.5.3/lib/bundler/runtime.rb:13:in `setup'
    from /Applications/Vagrant/embedded/gems/gems/bundler-1.5.3/lib/bundler.rb:119:in `setup'
    from /Applications/Vagrant/embedded/gems/gems/bundler-1.5.3/lib/bundler/setup.rb:17:in `<top (required)>'
    from /usr/local/Cellar/ruby/2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
    from /usr/local/Cellar/ruby/2.1.1/lib/ruby/2.1.0/rubygems/core_ext/kernel_require.rb:55:in `require'
```
