### PR TITLE
Require puppet/module_tool to access Puppet::ModuleTool on Puppet 3.5.0

### DIFF
--- a/lib/librarian/puppet/source/local.rb
+++ b/lib/librarian/puppet/source/local.rb
@@ -1,5 +1,6 @@
 begin
   require 'puppet'
+  require 'puppet/module_tool'
 rescue LoadError
   $stderr.puts <<-EOF
 Unable to load puppet, the puppet gem is required for :git and :path source.


### PR DESCRIPTION
In Puppet 3.5.0, it seems Puppet::ModuleTool is no longer accessible when
requiring 'puppet' alone, so specify the top level file that brings in
this namespace.  Otherwise you'll get:

<pre>
lib/librarian/puppet/source/local.rb:78:in `evaluate_modulefile': uninitialized constant Puppet::ModuleTool (NameError)
  from lib/librarian/puppet/source/local.rb:74:in `module_version'
  from lib/librarian/puppet/source/local.rb:42:in `fetch_version'
</pre>
