### PR TITLE
Fix error in error handling when puppet is not installed

### DIFF
--- a/lib/librarian/puppet.rb
+++ b/lib/librarian/puppet.rb
@@ -1,21 +1,6 @@
 require 'librarian'
 require 'fileutils'
 
-out = nil
-begin
-  out = Librarian::Posix.run!(%W{puppet --version})
-rescue Librarian::Posix::CommandFailure => error
-
-  $stderr.puts <<-EOF
-Unable to load puppet. Please install it using native packages for your platform (eg .deb, .rpm, .dmg, etc).
-puppet --version returned #{status.exitstatus}
-#{error.message unless error.message.nil?}
-EOF
-  exit 1
-end
-
-PUPPET_VERSION=out.split(' ').first.strip
-
 require 'librarian/puppet/extension'
 require 'librarian/puppet/version'
 
@@ -23,5 +8,22 @@ require 'librarian/action/install'
 
 module Librarian
   module Puppet
+    def puppet_version
+      out = nil
+      begin
+        out = Librarian::Posix.run!(%W{puppet --version})
+      rescue Librarian::Posix::CommandFailure => error
+
+        $stderr.puts <<-EOF
+      Unable to load puppet. Please install it using native packages for your platform (eg .deb, .rpm, .dmg, etc).
+      puppet --version returned #{error.status}
+      #{error.message unless error.message.nil?}
+      EOF
+        exit 1
+      end
+      out.split(' ').first.strip
+    end
   end
 end
+
+PUPPET_VERSION=Librarian::Puppet::puppet_version

--- a/spec/librarian_puppet_spec.rb
+++ b/spec/librarian_puppet_spec.rb
@@ -1,0 +1,14 @@
+describe Librarian::Puppet do
+  it 'exits with error if puppet is not installed' do
+    error = Librarian::Posix::CommandFailure.new 'puppet not installed'
+    error.status = 42
+
+    expect(Librarian::Posix).to receive(:run!).and_raise(error)
+    expect($stderr).to receive(:puts) do |message|
+      expect(message).to match /42/
+      expect(message).to match /puppet not installed/
+    end
+
+    expect { Librarian::Puppet::puppet_version }.to raise_error(SystemExit)
+  end
+end


### PR DESCRIPTION
Bug introduced by 3b694955db500f23665d481b34a3e7d6878ea3d6. The error message
generated in response to an error in running 'puppet --version' itself
generated a new error by referencing a 'status' method that does not exist.
