### PR TITLE
Stringify 'source' so the regex works

### DIFF
--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -106,7 +106,7 @@ module Librarian
 
             # TODO can't pass the default forge url (http://forge.puppetlabs.com) to clients that use the v3 API (https://forgeapi.puppetlabs.com)
             module_repository = source.to_s
-            if Forge.client_api_version() > 1 and source =~ %r{^http(s)?://forge\.puppetlabs\.com}
+            if Forge.client_api_version() > 1 and module_repository =~ %r{^http(s)?://forge\.puppetlabs\.com}
               module_repository = "https://forgeapi.puppetlabs.com"
               warn("Your Puppet client uses the Forge API v3, you should use this Forge URL: #{module_repository}")
             end


### PR DESCRIPTION
The fix for #190 was broken because the regex comparison was never going to evaluate to true due to a type issue.  This fixes that.
