### PR TITLE
puppet module tool needs to use '--force' on PE >= 3.2.1

### DIFF
--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -112,7 +112,7 @@ module Librarian
             end
 
             command = %W{puppet module install --version #{version} --target-dir}
-            command.push(*[path.to_s, "--module_repository", module_repository, "--modulepath", path.to_s, "--module_working_dir", path.to_s, "--ignore-dependencies", target])
+            command.push(*[path.to_s, "--module_repository", module_repository, "--modulepath", path.to_s, "--module_working_dir", path.to_s, "--force", target])
             debug { "Executing puppet module install for #{name} #{version}" }
 
             begin


### PR DESCRIPTION
Per https://github.com/rodjek/librarian-puppet/pull/190, in order to get around a 'supported modules' issue where the puppet module tool will fail install if you attempt to use a module 'supported' by that particular version of PE (such as using a newer stdlib, a common practice), the invocation needs to use '--force' instead of '--ignore-dependencies'.
