### PR TITLE
Updates client_api_version to 3 with puppet >= 3.6.0

### DIFF
--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -108,7 +108,6 @@ module Librarian
             module_repository = source.to_s
             if Forge.client_api_version() > 1 and module_repository =~ %r{^http(s)?://forge\.puppetlabs\.com}
               module_repository = "https://forgeapi.puppetlabs.com"
-              warn("Your Puppet client uses the Forge API v3, you should use this Forge URL: #{module_repository}")
             end
 
             command = %W{puppet module install --version #{version} --target-dir}
@@ -231,8 +230,11 @@ module Librarian
             version = 1
             pe_version = Librarian::Puppet.puppet_version.match(/\(Puppet Enterprise (.+)\)/)
 
+            # Puppet 3.6.0+ uses api v3
+            if Librarian::Puppet::puppet_gem_version >= Gem::Version.create('3.6.0.a')
+              version = 3
             # Puppet enterprise 3.2.0+ uses api v3
-            if pe_version and Gem::Version.create(pe_version[1].strip) >= Gem::Version.create('3.2.0')
+            elsif pe_version and Gem::Version.create(pe_version[1].strip) >= Gem::Version.create('3.2.0')
               version = 3
             end
             return version

--- a/spec/source/forge_spec.rb
+++ b/spec/source/forge_spec.rb
@@ -10,7 +10,8 @@ describe Forge do
   subject { Forge.new(environment, uri) }
 
   before do
-    Librarian::Puppet.should_receive(:puppet_version).and_return(puppet_version)
+    Librarian::Puppet.should_receive(:puppet_version).at_least(1).and_return(puppet_version)
+    Librarian::Puppet.should_receive(:puppet_gem_version).at_least(1).and_return(Gem::Version.create(puppet_version.split(' ').first.strip.gsub('-', '.')))
   end
 
   describe "#check_puppet_module_options" do
@@ -22,6 +23,10 @@ describe Forge do
       context "2.7.13" do
         let(:puppet_version) { "2.7.13" }
         it { Forge.client_api_version().should == 1 }
+      end
+      context "3.6.0" do
+        let(:puppet_version) { "3.6.0" }
+        it { Forge.client_api_version().should == 3 }
       end
     end
     context "Puppet Enterprise" do


### PR DESCRIPTION
Previously the client_api_version was only set to 3 with PE >= 3.2.0
PMT in Puppet >= 3.6.0 also requires the v3 forge api.

I also removed the misleading warning. I don't think librarian should recommend people use forgeapi until it implements v3.
