### PR TITLE
Don't warn about organization prefix when operating on a git source

### DIFF
--- a/lib/librarian/puppet/source/local.rb
+++ b/lib/librarian/puppet/source/local.rb
@@ -26,8 +26,10 @@ module Librarian
           found_path = found_path(name)
           raise Error, "Path for #{name} doesn't contain a puppet module" if found_path.nil?
 
-          unless name.include? '/'
-            warn { "Invalid module name '#{name}', you should qualify it with 'ORGANIZATION/#{name}' for resolution to work correctly" }
+          unless self.class.to_s == 'Librarian::Puppet::Source::Git'
+            unless name.include? '/'
+              warn { "Invalid module name '#{name}', you should qualify it with 'ORGANIZATION/#{name}' for resolution to work correctly" }
+            end
           end
 
           install_path = environment.install_path.join(name.split('/').last)


### PR DESCRIPTION
I have a module called `ntp`, which I'm pulling from a git repo. Without this patch, and just with this in my `Modulefile`:

``` ruby
mod 'ntp', :git => 'git://github.com/puppetlabs/puppetlabs-ntp.git'
```

will result in this warning:

```
Invalid module name 'ntp', you should qualify it with 'ORGANIZATION/ntp' for resolution to work correctly
```

The change in this PR will prevent that warning when operating on git sources.
