### PR TITLE
warn when changing puppet forge API URL

### DIFF
--- a/lib/librarian/puppet/source/forge.rb
+++ b/lib/librarian/puppet/source/forge.rb
@@ -55,7 +55,7 @@ module Librarian
 
           if uri =~ %r{^http(s)?://forge\.puppetlabs\.com}
             uri = "https://forgeapi.puppetlabs.com"
-            debug { "Replacing Puppet Forge API URL to use v3 #{uri}. You should update your Puppetfile" }
+            warn { "Replacing Puppet Forge API URL to use v3 #{uri}. You should update your Puppetfile" }
           end
 
           @uri = URI::parse(uri)


### PR DESCRIPTION
I'm not sure if warning violates some convention, but silently changing this URL led me on a wild-goose chase, thinking a bug in librarian-puppet was the problem. just submitting a humble suggestion to bump the log level here. cheers!
