### PR TITLE
Fix version regex to match e.g. 1.99.15

### DIFF
--- a/lib/librarian/puppet/source/githubtarball/repo.rb
+++ b/lib/librarian/puppet/source/githubtarball/repo.rb
@@ -25,7 +25,7 @@ module Librarian
             all_versions = data.map { |r| r['name'].gsub(/^v/, '') }.sort.reverse
 
             all_versions.delete_if do |version|
-              version !~ /\A\d\.\d(\.\d.*)?\z/
+              version !~ /\A\d+\.\d+(\.\d+.*)?\z/
             end
 
             @versions = all_versions.compact


### PR DESCRIPTION
fixes boxen/puppet-mysql#37
