### PR TITLE
Installation of modules without metadata nor modulefile fails

### DIFF
--- a/features/install.feature
+++ b/features/install.feature
@@ -40,3 +40,13 @@ Feature: cli/install
     """
     Unable to parse .*/bad_modulefile/Modulefile, ignoring: Missing version
     """
+
+  Scenario: Running install with no Modulefile nor metadata.json
+    Given a file named "Puppetfile" with:
+    """
+    forge "http://forge.puppetlabs.com"
+
+    mod 'puppetlabs/stdlib', :git => 'https://github.com/puppetlabs/puppetlabs-stdlib.git', :ref => '3.0.0'
+    """
+    When I run `librarian-puppet install`
+    Then the exit status should be 0

--- a/lib/librarian/puppet/source/local.rb
+++ b/lib/librarian/puppet/source/local.rb
@@ -118,8 +118,9 @@ module Librarian
               end
             }
           else
-            warn { "Could not find metadata.json nor Modulefile at #{filesystem_path}" }
-            {}
+            {
+              'dependencies' => []
+            }
           end
           @metadata
         end


### PR DESCRIPTION
Because of `fetch_dependencies`:

```
parsed_metadata['dependencies'].each
```

I will have a look..
