### PR TITLE
Raise self-explanatepry exception when no Modulefile/metadata.json.

### DIFF
--- a/lib/librarian/puppet/source/local.rb
+++ b/lib/librarian/puppet/source/local.rb
@@ -42,6 +42,10 @@ module Librarian
             dependencies.merge spec.dependencies
           end
 
+          unless parsed_metadata['dependencies']
+            raise Error, "#{name} has naither Modulefile/metadata.json file."
+          end
+
           parsed_metadata['dependencies'].each do |d|
             gem_requirement = Requirement.new(d['version_requirement']).gem_requirement
             new_dependency = Dependency.new(d['name'], gem_requirement, forge_source)


### PR DESCRIPTION
When no Modulefile/metadata.json nasty exception is raised:

```
/usr/local/share/ruby/gems/2.0/gems/librarian-puppet-1.3.1/lib/librarian/puppet/source/local.rb:45:in `fetch_dependencies': undefined method `each' for nil:NilClass (NoMethodError)
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/manifest.rb:125:in `fetch_dependencies!'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/manifest.rb:117:in `fetched_dependencies'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/manifest.rb:81:in `dependencies'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:117:in `block in check_manifest_for_cycles'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:117:in `each'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:117:in `map'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:117:in `check_manifest_for_cycles'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:64:in `block in recursive_resolve'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:154:in `block (3 levels) in resolving_dependency_map_find_manifests'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:187:in `block in scope_checking_manifest'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:223:in `scope'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:186:in `scope_checking_manifest'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:153:in `block (2 levels) in resolving_dependency_map_find_manifests'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:211:in `block in map_find'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:210:in `each'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:210:in `map_find'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:152:in `block in resolving_dependency_map_find_manifests'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:165:in `block (2 levels) in scope_resolving_dependency'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:179:in `block in scope_checking_manifests'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:223:in `scope'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:178:in `scope_checking_manifests'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:164:in `block in scope_resolving_dependency'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:223:in `scope'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:163:in `scope_resolving_dependency'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:151:in `resolving_dependency_map_find_manifests'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:62:in `recursive_resolve'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver/implementation.rb:50:in `resolve'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/resolver.rb:23:in `resolve'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/action/resolve.rb:26:in `run'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/cli.rb:169:in `resolve!'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-puppet-1.3.1/lib/librarian/puppet/cli.rb:67:in `install'
    from /usr/local/share/ruby/gems/2.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /usr/local/share/ruby/gems/2.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /usr/local/share/ruby/gems/2.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /usr/local/share/ruby/gems/2.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/cli.rb:26:in `block (2 levels) in bin!'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/cli.rb:31:in `returning_status'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/cli.rb:26:in `block in bin!'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/cli.rb:47:in `with_environment'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-0.1.2/lib/librarian/cli.rb:26:in `bin!'
    from /usr/local/share/ruby/gems/2.0/gems/librarian-puppet-1.3.1/bin/librarian-puppet:7:in `<top (required)>'
    from /usr/bin/librarian-puppet:23:in `load'
    from /usr/bin/librarian-puppet:23:in `<main>'
```
