### PR TITLE
Rsync option

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,6 +256,28 @@ Configuration can be set by passing specific options to other commands.
   the environment or global config will be used.
 
 
+## Rsync Option
+
+The default convergence strategy between the cache and the module directory is
+to execute an `rm -r` on the module directory and just `cp -r` from the cache.
+This causes the module to be removed from the module path every time librarian
+puppet updates, regardless of whether the content has changed. This can cause
+some problems in environments with lots of change. The problem arises when the
+module directory gets removed while Puppet is trying to read files inside it.
+The `puppet master` process will lose its CWD and the catalog will fail to
+compile. To avoid this, you can use `rsync` to implement a more conservative
+convergence strategy. This will use `rsync` with the `-avz` and `--delete`
+flags instead of a `rm -r` and `cp -r`. To use this feature, just set the
+`rsync` configuration setting to `true`.
+
+    $ librarian-puppet config rsync true --global
+
+Alternatively, using an environment variable:
+
+    LIBRARIAN_PUPPET_RSYNC='true'
+
+Note that the directories will still be purged if you run librarian-puppet with
+the --clean or --destructive flags.
 
 ## How to Contribute
 

--- a/features/install.feature
+++ b/features/install.feature
@@ -40,3 +40,75 @@ Feature: cli/install
     """
     Unable to parse .*/bad_modulefile/Modulefile, ignoring: Missing version
     """
+
+    Scenario: Install a module with the rsync configuration using the --clean flag
+      Given a file named "Puppetfile" with:
+      """
+      forge "http://forge.puppetlabs.com"
+
+      mod 'maestrodev/test'
+      """
+      And a file named ".librarian/puppet/config" with:
+      """
+      ---
+      LIBRARIAN_PUPPET_RSYNC: 'true'
+      """
+      When I run `librarian-puppet config`
+      Then the exit status should be 0
+      And the output should contain "rsync: true"
+      When I run `librarian-puppet install`
+      Then the exit status should be 0
+      And a directory named "modules/test" should exist
+      And the file "modules/test" should have an inode and ctime
+      When I run `librarian-puppet install --clean`
+      Then the exit status should be 0
+      And a directory named "modules/test" should exist
+      And the file "modules/test" should not have the same inode or ctime as before
+
+    Scenario: Install a module with the rsync configuration using the --destructive flag
+      Given a file named "Puppetfile" with:
+      """
+      forge "http://forge.puppetlabs.com"
+
+      mod 'maestrodev/test'
+      """
+      And a file named ".librarian/puppet/config" with:
+      """
+      ---
+      LIBRARIAN_PUPPET_RSYNC: 'true'
+      """
+      When I run `librarian-puppet config`
+      Then the exit status should be 0
+      And the output should contain "rsync: true"
+      When I run `librarian-puppet install`
+      Then the exit status should be 0
+      And a directory named "modules/test" should exist
+      And the file "modules/test" should have an inode and ctime
+      When I run `librarian-puppet install --destructive`
+      Then the exit status should be 0
+      And a directory named "modules/test" should exist
+      And the file "modules/test" should not have the same inode or ctime as before
+
+    Scenario: Install a module with the rsync configuration
+      Given a file named "Puppetfile" with:
+      """
+      forge "http://forge.puppetlabs.com"
+
+      mod 'maestrodev/test'
+      """
+      And a file named ".librarian/puppet/config" with:
+      """
+      ---
+      LIBRARIAN_PUPPET_RSYNC: 'true'
+      """
+      When I run `librarian-puppet config`
+      Then the exit status should be 0
+      And the output should contain "rsync: true"
+      When I run `librarian-puppet install`
+      Then the exit status should be 0
+      And a directory named "modules/test" should exist
+      And the file "modules/test" should have an inode and ctime
+      When I run `librarian-puppet install`
+      Then the exit status should be 0
+      And a directory named "modules/test" should exist
+      And the file "modules/test" should have the same inode and ctime as before

--- a/features/step_definitions/convergence_steps.rb
+++ b/features/step_definitions/convergence_steps.rb
@@ -1,0 +1,28 @@
+Then /^the file "([^"]*)" should have an inode and ctime$/ do |file|
+    prep_for_fs_check do
+        stat = File.stat(File.expand_path(file))
+        @before_inode = { 'ino' => stat.ino, 'ctime' => stat.ctime }
+        expect(@before_inode['ino']).not_to eq nil
+        expect(@before_inode['ctime']).not_to eq nil
+    end
+end
+
+Then /^the file "([^"]*)" should have the same inode and ctime as before$/ do |file|
+    prep_for_fs_check do
+        stat = File.stat(File.expand_path(file))
+        expect(stat.ino).to eq @before_inode['ino']
+        expect(stat.ctime).to eq @before_inode['ctime']
+    end
+end
+
+Then /^the file "([^"]*)" should not have the same inode or ctime as before$/ do |file|
+    prep_for_fs_check do
+        stat = File.stat(File.expand_path(file))
+
+        begin
+            expect(stat.ino).not_to eq @before_inode['ino']
+        rescue RSpec::Expectations::ExpectationNotMetError
+            expect(stat.ctime).not_to eq @before_inode['ctime']
+        end
+    end
+end

--- a/lib/librarian/puppet/source/forge/repo.rb
+++ b/lib/librarian/puppet/source/forge/repo.rb
@@ -55,7 +55,7 @@ module Librarian
 
             cache_version_unpacked! version
 
-            if install_path.exist?
+            if install_path.exist? && rsync? != true
               install_path.rmtree
             end
 

--- a/lib/librarian/puppet/source/githubtarball/repo.rb
+++ b/lib/librarian/puppet/source/githubtarball/repo.rb
@@ -48,7 +48,7 @@ module Librarian
 
             cache_version_unpacked! version
 
-            if install_path.exist?
+            if install_path.exist? && rsync? != true
               install_path.rmtree
             end
 

--- a/lib/librarian/puppet/source/local.rb
+++ b/lib/librarian/puppet/source/local.rb
@@ -20,7 +20,7 @@ module Librarian
           end
 
           install_path = environment.install_path.join(organization_name(name))
-          if install_path.exist?
+          if install_path.exist? && rsync? != true
             debug { "Deleting #{relative_path_to(install_path)}" }
             install_path.rmtree
           end

--- a/lib/librarian/puppet/util.rb
+++ b/lib/librarian/puppet/util.rb
@@ -1,3 +1,5 @@
+require 'rsync'
+
 module Librarian
   module Puppet
 
@@ -13,16 +15,26 @@ module Librarian
         environment.logger.warn(*args, &block)
       end
 
+      def rsync?
+          environment.config_db.local['rsync'] == 'true'
+      end
+
       # workaround Issue #173 FileUtils.cp_r will fail if there is a symlink that points to a missing file
       # or when the symlink is copied before the target file when preserve is true
       # see also https://tickets.opscode.com/browse/CHEF-833
+      #
+      # If the rsync configuration parameter is set, use rsync instead of FileUtils
       def cp_r(src, dest)
-        begin
-          FileUtils.cp_r(src, dest, :preserve => true)
-        rescue Errno::ENOENT
-          debug { "Failed to copy from #{src} to #{dest} preserving file types, trying again without preserving them" }
-          FileUtils.rm_rf(dest)
-          FileUtils.cp_r(src, dest)
+        if rsync?
+          Rsync.run(File.join(src, "/"), dest, ['-avz', '--delete'])
+        else
+          begin
+            FileUtils.cp_r(src, dest, :preserve => true)
+          rescue Errno::ENOENT
+            debug { "Failed to copy from #{src} to #{dest} preserving file types, trying again without preserving them" }
+            FileUtils.rm_rf(dest)
+            FileUtils.cp_r(src, dest)
+          end
         end
       end
 

--- a/librarian-puppet.gemspec
+++ b/librarian-puppet.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.executables = ['librarian-puppet']
 
   s.add_dependency "librarian", ">=0.1.2"
+  s.add_dependency "rsync"
   s.add_dependency "puppet_forge"
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
We're using librarian-puppet in a large-scale environment with lots of change and we've run into issues with librarian-puppet's rather liberal convergence strategy. Essentially we're running into an issue where a `librarian-puppet update` command will result in a Puppet master process losing it's CWD because of the `install_path.rmtree` call. This results in a catalog compilation failure. The `install_path.rmtree` method gets called regardless of whether there are changes to the module in `install_path`. This PR allows for the option to use rsync to converge the directories, which is ultimately a much more conservative convergence strategy. This may not be the most idiomatic implementation. I'm open to suggestions on how to improve it.
