### PR TITLE
Fix for ignored forge URL when using APIv3

### DIFF
--- a/lib/librarian/puppet/source/forge/repo_v3.rb
+++ b/lib/librarian/puppet/source/forge/repo_v3.rb
@@ -10,6 +10,11 @@ module Librarian
 
           PuppetForge.user_agent = "librarian-puppet/#{Librarian::Puppet::VERSION}"
 
+          def initialize(source, name)
+            PuppetForge.host = source.uri.clone
+            super(source, name)
+          end
+
           def get_versions
             get_module.releases.map{|r| r.version}
           end


### PR DESCRIPTION
Repo for APIv3 is using PuppetForge as API client. PuppetForge is using https://forgeapi.puppetlabs.com remote URL by default. So, if you set custom forge URL in Puppetfile and run librarian-puppet with --no-use-v1-api, it will ignore your forge URL and use official forge.

I have added constructor for repo v3 which sets PuppetForge remote URL.

@rodjek, are you interested in merging this?
