### PR TITLE
Windows FileUtils.cp_r fix

### DIFF
--- a/lib/librarian/puppet/util.rb
+++ b/lib/librarian/puppet/util.rb
@@ -30,7 +30,7 @@ module Librarian
         else
           begin
             FileUtils.cp_r(src, dest, :preserve => true)
-          rescue Errno::ENOENT
+          rescue Errno::ENOENT, Errno::EACCES
             debug { "Failed to copy from #{src} to #{dest} preserving file types, trying again without preserving them" }
             FileUtils.rm_rf(dest)
             FileUtils.cp_r(src, dest)


### PR DESCRIPTION
The use of :preserve can cause permission problems on Windows. This commit simply adds the Errno::EACCES exception to the rescue statement to recover from it.
