### PR TITLE
Moved the cache-check to below the super, as the SHA is not yet known

### DIFF
--- a/lib/librarian/puppet/source/git.rb
+++ b/lib/librarian/puppet/source/git.rb
@@ -25,8 +25,6 @@ module Librarian
         include Librarian::Puppet::Util
 
         def cache!
-          return vendor_checkout! if vendor_cached?
-
           if environment.local?
             raise Error, "Could not find a local copy of #{uri}#{" at #{sha}" unless sha.nil?}."
           end
@@ -36,6 +34,8 @@ module Librarian
           rescue Librarian::Posix::CommandFailure => e
             raise Error, "Could not checkout #{uri}#{" at #{sha}" unless sha.nil?}: #{e}"
           end
+
+          return vendor_checkout! if vendor_cached?
 
           cache_in_vendor(repository.path) if environment.vendor?
         end


### PR DESCRIPTION
We had an issue at work where gzip failed because the file was already there. The cause for this issue was that the vendor_cached? was checking without the sha in the file.

By moving the cache-call below the super call, we will know the sha and therefor can do the correct check.
