### PR TITLE
Fix for #293

### DIFF
--- a/lib/librarian/puppet/source/forge/repo.rb
+++ b/lib/librarian/puppet/source/forge/repo.rb
@@ -135,7 +135,7 @@ module Librarian
             min_version    = Gem::Version.create('2.7.13')
 
             if Librarian::Puppet.puppet_gem_version < min_version
-              raise Error, "To get modules from the forge, we use the puppet faces module command. For this you need at least puppet version 2.7.13 and you have #{puppet_version}"
+              raise Error, "To get modules from the forge, we use the puppet faces module command. For this you need at least puppet version 2.7.13 and you have #{Librarian::Puppet.puppet_version}"
             end
           end
 


### PR DESCRIPTION
This is a possible fix for #293. 

With this patch I get the following error that make me think the preceding error (undefined local variable) is fixed.

```
~/tmp $ librarian-puppet install --verbose
[Librarian] Ruby Version: 2.0.0
[Librarian] Ruby Platform: universal.x86_64-darwin14
[Librarian] Rubygems Version: 2.0.14
[Librarian] Librarian Version: 0.6.2
[Librarian] Librarian Adapter: puppet
[Librarian] Librarian Adapter Version: 2.1.0
[Librarian] Project: /Users/m/tmp
[Librarian] Specfile: Puppetfile
[Librarian] Lockfile: Puppetfile.lock
[Librarian] Git: /opt/local/bin/git
[Librarian] Git Version: 2.3.5
[Librarian] Git Environment Variables:
[Librarian]   (empty)
[Librarian] Pre-Cached Sources:
[Librarian]   [:forge, "http://puppet-library.fr.corp.acme.com", {}]
[Librarian]   [:git, "http://blah.fr.corp.acme.com/group/module_name.git", {:ref=>"0.0.4"}]
[Librarian] Post-Cached Sources:
[Librarian]   [:forge, "http://puppet-library.fr.corp.acme.com", {}]
[Librarian]   [:git, "http://blah.fr.corp.acme.com/group/module_name.git", {:ref=>"0.0.4"}]
[Librarian] The specfile is unchanged: nothing to do.
[Librarian] Install: dependencies resolved
[Librarian] Installing puppetlabs-stdlib/4.6.0 <http://puppet-library.fr.corp.acme.com>
To get modules from the forge, we use the puppet faces module command. For this you need at least puppet version 2.7.13 and you have 2.7.6
/Library/Ruby/Gems/2.0.0/gems/librarian-puppet-2.1.0/lib/librarian/puppet/source/forge/repo.rb:138:in `check_puppet_module_options'
/Library/Ruby/Gems/2.0.0/gems/librarian-puppet-2.1.0/lib/librarian/puppet/source/forge/repo.rb:83:in `cache_version_unpacked!'
/Library/Ruby/Gems/2.0.0/gems/librarian-puppet-2.1.0/lib/librarian/puppet/source/forge/repo.rb:56:in `install_version!'
/Library/Ruby/Gems/2.0.0/gems/librarian-puppet-2.1.0/lib/librarian/puppet/source/forge.rb:114:in `install!'
/Library/Ruby/Gems/2.0.0/gems/librarianp-0.6.2/lib/librarian/manifest.rb:73:in `install!'
/Library/Ruby/Gems/2.0.0/gems/librarianp-0.6.2/lib/librarian/action/install.rb:49:in `block in install_manifests'
/Library/Ruby/Gems/2.0.0/gems/librarianp-0.6.2/lib/librarian/action/install.rb:48:in `each'
/Library/Ruby/Gems/2.0.0/gems/librarianp-0.6.2/lib/librarian/action/install.rb:48:in `install_manifests'
/Library/Ruby/Gems/2.0.0/gems/librarianp-0.6.2/lib/librarian/action/install.rb:39:in `perform_installation'
/Library/Ruby/Gems/2.0.0/gems/librarianp-0.6.2/lib/librarian/action/install.rb:12:in `run'
/Library/Ruby/Gems/2.0.0/gems/librarian-puppet-2.1.0/lib/librarian/puppet/cli.rb:101:in `install!'
/Library/Ruby/Gems/2.0.0/gems/librarian-puppet-2.1.0/lib/librarian/puppet/cli.rb:70:in `install'
/Library/Ruby/Gems/2.0.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
/Library/Ruby/Gems/2.0.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
/Library/Ruby/Gems/2.0.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
/Library/Ruby/Gems/2.0.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
/Library/Ruby/Gems/2.0.0/gems/librarianp-0.6.2/lib/librarian/cli.rb:26:in `block (2 levels) in bin!'
/Library/Ruby/Gems/2.0.0/gems/librarianp-0.6.2/lib/librarian/cli.rb:31:in `returning_status'
/Library/Ruby/Gems/2.0.0/gems/librarianp-0.6.2/lib/librarian/cli.rb:26:in `block in bin!'
/Library/Ruby/Gems/2.0.0/gems/librarianp-0.6.2/lib/librarian/cli.rb:47:in `with_environment'
/Library/Ruby/Gems/2.0.0/gems/librarianp-0.6.2/lib/librarian/cli.rb:26:in `bin!'
/Library/Ruby/Gems/2.0.0/gems/librarian-puppet-2.1.0/bin/librarian-puppet:7:in `<top (required)>'
/usr/bin/librarian-puppet:23:in `load'
/usr/bin/librarian-puppet:23:in `<main>'
```