### PR TITLE
Add pessimistic constraint to puppet_forge dependency

### DIFF
--- a/librarian-puppet.gemspec
+++ b/librarian-puppet.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "librarianp", ">=0.6.2"
   s.add_dependency "rsync"
-  s.add_dependency "puppet_forge"
+  s.add_dependency "puppet_forge", "~> 1.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec"


### PR DESCRIPTION
At some point there will probably be a 2.x release of the puppet_forge gem that may not be backwards compatible. Pessimistic version constraints on dependencies is also a RubyGems best practice: http://guides.rubygems.org/patterns/#declaring-dependencies