### PR TITLE
fix bug when using passed in project_dir when using the API directly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,4 @@
 source 'https://rubygems.org'
 gemspec
+
+gem 'pry'

--- a/lib/librarian/puppet/dsl.rb
+++ b/lib/librarian/puppet/dsl.rb
@@ -42,7 +42,7 @@ module Librarian
 
         # save the specfile and call librarian
         def run(specfile = nil)
-          @working_path = specfile.kind_of?(Pathname) ? specfile.parent : Pathname.new(Dir.pwd)
+          @working_path = specfile.kind_of?(Pathname) ? specfile.parent : Pathname(Dir.pwd)
           @specfile = specfile
           super
         end

--- a/spec/receiver_spec.rb
+++ b/spec/receiver_spec.rb
@@ -5,7 +5,7 @@ describe 'Librarian::Puppet::Dsl::Receiver' do
   let(:dsl) { Librarian::Puppet::Dsl.new({}) }
   let(:target) { Librarian::Dsl::Target.new(dsl) }
   let(:receiver) { Librarian::Puppet::Dsl::Receiver.new(target) }
-
+  let(:environment) { Librarian::Puppet::Environment.new(:project_path => '/tmp/tmp_module') }
   describe '#run' do
 
     it 'should get working_dir from pwd when specfile is nil' do
@@ -19,8 +19,15 @@ describe 'Librarian::Puppet::Dsl::Receiver' do
     end
 
     it 'should get working_dir from given path' do
-      receiver.run(Pathname.new('/tmp/tmp_module/Puppetfile')) {}
+      allow(environment.specfile).to receive(:kind_of?).with(:Pathname)
+      allow(environment.specfile).to receive(:parent)
+      receiver.run(environment.specfile) {}
       expect(receiver.working_path).to eq(Pathname.new('/tmp/tmp_module'))
+    end
+
+    it 'test receiver run' do
+      error_message = 'Metadata file does not exist: '+File.join(environment.project_path, 'metadata.json')
+      expect{environment.dsl(environment.specfile.path, [])}.to raise_error(Librarian::Error,error_message)
     end
   end
 end


### PR DESCRIPTION
When using the API directly for example:

```ruby
    e = Librarian::Puppet::Environment.new(:project_path => project_path)
```

The path is ignored in the DSL because of a bug. (https://github.com/logicminds/librarian-puppet/blob/master/lib/librarian/puppet/dsl.rb#L45)

This is easily fixed by traversing the path method.

```ruby
specfile.path.kind_of?(Pathname)
```

Additionally,  I attempted to create some tests for this but they are incomplete as I am unsure how to create the test with regards to setting a target.  Hoping you can help with this so I can finish the tests and get this PR merge and tested.

```ruby
  rec = Librarian::Puppet::Receiver.new(target)
```

Since most people never use the API like this this bug has been masked for a while.