### PR TITLE
Allow the use of librarian puppet without a forge

### DIFF
--- a/lib/librarian/puppet/cli.rb
+++ b/lib/librarian/puppet/cli.rb
@@ -47,6 +47,7 @@ module Librarian
       option "destructive", :type => :boolean, :default => false
       option "local", :type => :boolean, :default => false
       option "use-v1-api", :type => :boolean, :default => true
+      option "use-forge", :type => :boolean
       def install
 
         ensure!
@@ -63,6 +64,9 @@ module Librarian
         end
 
         environment.config_db.local['use-v1-api'] = options['use-v1-api'] ? '1' : nil
+        unless options["use-forge"].nil?
+          environment.config_db.local['use-forge'] = options['use-forge'].to_s
+        end
         environment.config_db.local['mode'] = options['local'] ? 'local' : nil
 
         resolve!
@@ -84,6 +88,7 @@ module Librarian
       option "strip-dot-git", :type => :boolean
       option "path", :type => :string
       option "destructive", :type => :boolean, :default => false
+      option "use-forge", :type => :boolean
       def package
         environment.vendor!
         install

--- a/lib/librarian/puppet/environment.rb
+++ b/lib/librarian/puppet/environment.rb
@@ -57,6 +57,10 @@ module Librarian
       def use_v1_api
         config_db['use-v1-api']
       end
+
+      def use_forge
+        config_db['use-forge'].to_s == 'false' ? false : true
+      end
     end
   end
 end


### PR DESCRIPTION
This update adds support for using librarian puppet without a forge.

Setting the LIBRARIAN_PUPPET_USE_FORGE binary option in one of the
configuration files will prevent the utility from reaching out to a
forge for dependency resolution.

Fixes #325